### PR TITLE
feat: Add tarball release variant for Linux

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,5 @@
 # Main workflow for testing and releasing
+# spellchecker: disable
 
 name: CI/CD
 
@@ -6,76 +7,115 @@ env:
   GOVERSION: "1.23"
   NAME: "janice"
   FULLNAME: "Janice"
-  FULLNAME2: "Janice"  # for AppImage file, e.g. with spaces replaced by underscores
+  FULLNAME2: "Janice" # for AppImage file, e.g. with spaces replaced by underscores
   VERSION: "0.0.0"
 
 on: push
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GOVERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
 
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc libgl1-mesa-dev xorg-dev
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc libgl1-mesa-dev xorg-dev
 
-    - name: Install dependencies
-      run: go mod download
+      - name: Install dependencies
+        run: go mod download
 
-    - name: Test
-      run: go test -coverprofile=coverage.txt ./...
+      - name: Test
+        run: go test -coverprofile=coverage.txt ./...
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   package_linux:
     if: startsWith(github.ref, 'refs/tags/')
     needs: test
-    runs-on: ubuntu-22.04  # oldest available image = best AppImage compatibility
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GOVERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
 
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc libgl1-mesa-dev xorg-dev libfuse2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc libgl1-mesa-dev xorg-dev libfuse2
 
-    - name: Install Fyne tool
-      run: go install fyne.io/tools/cmd/fyne@latest
+      - name: Install Fyne tool
+        run: go install fyne.io/tools/cmd/fyne@latest
 
-    - name: Package Fyne app
-      run: fyne package -os linux --release --tags migrated_fynedo
+      - name: Set version
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-    - name: Set version
-      run: |
-        VERSION=${{ github.ref_name }}
-        echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+      - name: Package Fyne app
+        run: |
+          run: fyne package -os linux --release --tags migrated_fynedo
+          mv ${{ env.FULLNAME }}.tar.xz ${{ env.NAME }}-${{ env.VERSION }}-linux-amd64.tar.xz
 
-    - name: Build AppImage
-      run: ./tools/build_appimage.sh
+      - name: Inspect
+        run: ls -R
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.NAME }}-linux
-        path: ${{ env.FULLNAME2 }}-${{ env.VERSION }}-x86_64.AppImage
-        if-no-files-found: error
-        overwrite: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-linux
+          path: ${{ env.NAME }}-${{ env.VERSION }}-linux-amd64.tar.xz
+          if-no-files-found: error
+          overwrite: true
+
+  package_appimage:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: test
+    runs-on: ubuntu-22.04 # oldest available image = best AppImage compatibility
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc libgl1-mesa-dev xorg-dev libfuse2
+
+      - name: Install Fyne tool
+        run: go install fyne.io/tools/cmd/fyne@latest
+
+      - name: Package Fyne app
+        run: fyne package -os linux --release --tags migrated_fynedo
+
+      - name: Set version
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+
+      - name: Build AppImage
+        run: ./tools/build_appimage.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-appimage
+          path: ${{ env.FULLNAME2 }}-${{ env.VERSION }}-x86_64.AppImage
+          if-no-files-found: error
+          overwrite: true
 
   package_windows:
     if: startsWith(github.ref, 'refs/tags/')
@@ -85,146 +125,154 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        update: true
+      - uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+          update: true
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GOVERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
 
-    - name: Install Dependencies
-      run: >
-        pacman -Syu &&
-        pacman --noconfirm -S git zip mingw-w64-x86_64-toolchain
+      - name: Install Dependencies
+        run: >
+          pacman -Syu &&
+          pacman --noconfirm -S git zip mingw-w64-x86_64-toolchain
 
-    - name: Install Fyne tool
-      run: go install fyne.io/tools/cmd/fyne@latest
+      - name: Install Fyne tool
+        run: go install fyne.io/tools/cmd/fyne@latest
 
-    - name: Package
-      run: fyne package -os windows --release --tags migrated_fynedo
+      - name: Package
+        run: fyne package -os windows --release --tags migrated_fynedo
 
-    - name: Set version
-      run: |
-        VERSION=${{ github.ref_name }}
-        echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+      - name: Set version
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-    - name: ZIP package
-      run: zip ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip "${{ env.FULLNAME }}.exe"
+      - name: ZIP package
+        run: zip ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip "${{ env.FULLNAME }}.exe"
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.NAME }}-windows
-        path: ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip
-        if-no-files-found: error
-        overwrite: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-windows
+          path: ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip
+          if-no-files-found: error
+          overwrite: true
 
   package_darwin_arm:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: macos-14
     needs: test
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GOVERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GOVERSION }}
 
-    - name: Install Fyne tool
-      run: go install fyne.io/tools/cmd/fyne@latest
+      - name: Install Fyne tool
+        run: go install fyne.io/tools/cmd/fyne@latest
 
-    - name: Package app bundles
-      run: fyne package -os darwin --release --tags migrated_fynedo
+      - name: Package app bundles
+        run: fyne package -os darwin --release --tags migrated_fynedo
 
-    - name: Set version
-      run: |
-        VERSION=${{ github.ref_name }}
-        echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+      - name: Set version
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-    - name: ZIP app bundle
-      run: zip --symlinks -r ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip "${{ env.FULLNAME }}.app/"
+      - name: ZIP app bundle
+        run: zip --symlinks -r ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip "${{ env.FULLNAME }}.app/"
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.NAME }}-macos-arm
-        path: ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip
-        if-no-files-found: error
-        overwrite: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-macos-arm
+          path: ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip
+          if-no-files-found: error
+          overwrite: true
 
   package_darwin_intel:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: macos-13
     needs: test
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GOVERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GOVERSION }}
 
-    - name: Install Fyne tool
-      run: go install fyne.io/tools/cmd/fyne@latest
+      - name: Install Fyne tool
+        run: go install fyne.io/tools/cmd/fyne@latest
 
-    - name: Package app bundles
-      run: fyne package -os darwin --release --tags migrated_fynedo
+      - name: Package app bundles
+        run: fyne package -os darwin --release --tags migrated_fynedo
 
-    - name: Set version
-      run: |
-        VERSION=${{ github.ref_name }}
-        echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+      - name: Set version
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-    - name: ZIP app bundle
-      run: zip --symlinks -r ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip "${{ env.FULLNAME }}.app/"
+      - name: ZIP app bundle
+        run: zip --symlinks -r ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip "${{ env.FULLNAME }}.app/"
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.NAME }}-macos-intel
-        path: ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip
-        if-no-files-found: error
-        overwrite: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-macos-intel
+          path: ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip
+          if-no-files-found: error
+          overwrite: true
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [package_linux, package_darwin_arm, package_darwin_intel, package_windows]
+    needs:
+      [
+        package_appimage,
+        package_darwin_arm,
+        package_darwin_intel,
+        package_linux,
+        package_windows,
+      ]
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
-      with:
-        merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
 
-    - name: Make version string
-      run: |
-        VERSION=${{ github.ref_name }}
-        echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+      - name: Make version string
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-    - name: Create release
-      uses: softprops/action-gh-release@v2
-      with:
-        fail_on_unmatched_files: true
-        files: |
-          ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip
-          ${{ env.FULLNAME2 }}-${{ env.VERSION }}-x86_64.AppImage
-          ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip
-          ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            ${{ env.NAME }}-${{ env.VERSION }}-windows-x64.zip
+            ${{ env.FULLNAME2 }}-${{ env.VERSION }}-x86_64.AppImage
+            ${{ env.NAME }}-${{ env.VERSION }}-linux-amd64.tar.xz
+            ${{ env.NAME }}-${{ env.VERSION }}-darwin-arm64.zip
+            ${{ env.NAME }}-${{ env.VERSION }}-darwin-intel64.zip

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,7 +60,7 @@ jobs:
       run: go install fyne.io/tools/cmd/fyne@latest
 
     - name: Package Fyne app
-      run: fyne package -os linux --release
+      run: fyne package -os linux --release --tags migrated_fynedo
 
     - name: Set version
       run: |
@@ -106,7 +106,7 @@ jobs:
       run: go install fyne.io/tools/cmd/fyne@latest
 
     - name: Package
-      run: fyne package -os windows --release
+      run: fyne package -os windows --release --tags migrated_fynedo
 
     - name: Set version
       run: |
@@ -145,7 +145,7 @@ jobs:
       run: go install fyne.io/tools/cmd/fyne@latest
 
     - name: Package app bundles
-      run: fyne package -os darwin --release
+      run: fyne package -os darwin --release --tags migrated_fynedo
 
     - name: Set version
       run: |
@@ -184,7 +184,7 @@ jobs:
       run: go install fyne.io/tools/cmd/fyne@latest
 
     - name: Package app bundles
-      run: fyne package -os darwin --release
+      run: fyne package -os darwin --release --tags migrated_fynedo
 
     - name: Set version
       run: |

--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -4,8 +4,8 @@ Website = "https://github.com/ErikKalkoken/janice"
   Icon = "icon.png"
   Name = "Janice"
   ID = "io.github.erikkalkoken.janice"
-  Version = "0.9.0"
-  Build = 3
+  Version = "0.10.0"
+  Build = 0
 
 [Release]
   BuildName = "janice"

--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -5,7 +5,7 @@ Website = "https://github.com/ErikKalkoken/janice"
   Name = "Janice"
   ID = "io.github.erikkalkoken.janice"
   Version = "0.9.0"
-  Build = 2
+  Build = 3
 
 [Release]
   BuildName = "janice"
@@ -19,6 +19,3 @@ Website = "https://github.com/ErikKalkoken/janice"
   Categories = ["Utility"]
   Comment = "A desktop app for viewing large JSON files"
   Keywords = ["json", "viewer"]
-
-[Migrations]
-  fyneDo = true

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ appimage:
 	./tools/build_appimage.sh
 
 release:
-	fyne package -os linux --release
+	fyne package -os linux --release --tags migrated_fynedo

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ To run Janice just download and unzip the latest release to your computer. Janic
 
 ### Linux
 
+We are providing two variants for installing on Linux desktop:
+
+- AppImage: The AppImage variant allows you to run the app directly from the executable without requiring installation or root access
+- Tarball: The tar file requires installation, but also allows you to integrate the app into your desktop environment. The tarball also has wider compatibility among different Linux versions.
+
+#### AppImage
+
 > [!NOTE]
 > The app is shipped in the [AppImage](https://appimage.org/) format, so it can be used without requiring installation and run on many different Linux distributions.
 
@@ -57,6 +64,16 @@ To run Janice just download and unzip the latest release to your computer. Janic
 
 > [!TIP]
 > Should you get the following error: `AppImages require FUSE to run.`, you need to first install FUSE on your system. Thi s is a library required by all AppImages to function. Please see [this page](https://docs.appimage.org/user-guide/troubleshooting/fuse.html#the-appimage-tells-me-it-needs-fuse-to-run) for details.
+
+#### Tarball
+
+1. Download the latest tar file from the releases page
+1. Decompress the tar file, for example with: `tar xf janice-0.12.3-linux-amd64.tar.xz`
+1. Run `make user-install` to install the app for the current user or run `sudo make install` to install the app on the system
+
+You should now have a shortcut in your desktop environment's launcher for starting the app.
+
+To uninstall the app again run either: `make user-uninstall` or `sudo make uninstall` depending on how you installed it.
 
 ### Windows
 


### PR DESCRIPTION
This adds a tarball release variant for Linux. The tarball is the default release format for Fyne apps on Linux and provides wider compatibility with different Linux variants then AppImage.